### PR TITLE
fix: Use schema to drive diffing

### DIFF
--- a/provider/cmd/pulumi-resource-turso/schema.json
+++ b/provider/cmd/pulumi-resource-turso/schema.json
@@ -240,15 +240,18 @@
         },
         "group": {
           "type": "string",
-          "description": "The name of the group where the database belongs. The group must already exist."
+          "description": "The name of the group where the database belongs. The group must already exist.",
+          "replaceOnChanges": true
         },
         "name": {
           "type": "string",
-          "description": "The name of the database. Must be unique within the organization."
+          "description": "The name of the database. Must be unique within the organization.",
+          "replaceOnChanges": true
         },
         "seed": {
           "$ref": "#/types/turso:index:DatabaseSeedArgs",
-          "description": "Configuration for seeding the database from an existing database or dump."
+          "description": "Configuration for seeding the database from an existing database or dump.",
+          "replaceOnChanges": true
         },
         "sizeLimit": {
           "type": "string",
@@ -367,11 +370,13 @@
         },
         "name": {
           "type": "string",
-          "description": "The name of the group. Must be unique within the organization."
+          "description": "The name of the group. Must be unique within the organization.",
+          "replaceOnChanges": true
         },
         "primaryLocation": {
           "type": "string",
-          "description": "The primary location (region) for the group. This is where the primary database instance will be created."
+          "description": "The primary location (region) for the group. This is where the primary database instance will be created.",
+          "replaceOnChanges": true
         },
         "replicaLocations": {
           "type": "array",

--- a/provider/databaseResource.go
+++ b/provider/databaseResource.go
@@ -19,12 +19,12 @@ func (d *Database) Annotate(a infer.Annotator) {
 }
 
 type DatabaseArgs struct {
-	Group       string            `pulumi:"group"`
-	Name        string            `pulumi:"name"`
+	Group       string            `pulumi:"group" provider:"replaceOnChanges"`
+	Name        string            `pulumi:"name" provider:"replaceOnChanges"`
 	BlockReads  *bool             `pulumi:"blockReads,optional"`
 	BlockWrites *bool             `pulumi:"blockWrites,optional"`
 	SizeLimit   *string           `pulumi:"sizeLimit,optional"`
-	Seed        *DatabaseSeedArgs `pulumi:"seed,optional"`
+	Seed        *DatabaseSeedArgs `pulumi:"seed,optional" provider:"replaceOnChanges"`
 }
 
 var _ infer.Annotated = (*DatabaseArgs)(nil)
@@ -122,7 +122,6 @@ var (
 	_ infer.CustomRead[DatabaseArgs, DatabaseState]   = (*Database)(nil)
 	_ infer.CustomUpdate[DatabaseArgs, DatabaseState] = (*Database)(nil)
 	_ infer.CustomDelete[DatabaseState]               = (*Database)(nil)
-	_ infer.CustomDiff[DatabaseArgs, DatabaseState]   = (*Database)(nil)
 )
 
 func (*Database) Create(ctx context.Context, req infer.CreateRequest[DatabaseArgs]) (infer.CreateResponse[DatabaseState], error) {
@@ -262,32 +261,6 @@ func (*Database) Delete(ctx context.Context, req infer.DeleteRequest[DatabaseSta
 	}
 
 	return infer.DeleteResponse{}, nil
-}
-
-func (*Database) Diff(ctx context.Context, req infer.DiffRequest[DatabaseArgs, DatabaseState]) (infer.DiffResponse, error) {
-	olds := req.State
-	news := req.Inputs
-	diff := map[string]p.PropertyDiff{}
-	if olds.BlockReads != UnwrapOrZero(news.BlockReads) {
-		diff["blockReads"] = p.PropertyDiff{Kind: p.Update}
-	}
-	if olds.BlockWrites != UnwrapOrZero(news.BlockWrites) {
-		diff["blockWrites"] = p.PropertyDiff{Kind: p.Update}
-	}
-	if olds.SizeLimit != UnwrapOrZero(news.SizeLimit) {
-		diff["sizeLimit"] = p.PropertyDiff{Kind: p.Update}
-	}
-	if olds.Group != news.Group {
-		diff["group"] = p.PropertyDiff{Kind: p.UpdateReplace}
-	}
-	if olds.Name != news.Name {
-		diff["name"] = p.PropertyDiff{Kind: p.UpdateReplace}
-	}
-	return infer.DiffResponse{
-		DeleteBeforeReplace: true,
-		HasChanges:          len(diff) > 0,
-		DetailedDiff:        diff,
-	}, nil
 }
 
 func optString(s *string) tursoclient.OptString {

--- a/provider/databaseResource_test.go
+++ b/provider/databaseResource_test.go
@@ -14,6 +14,119 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestDatabaseResource_ReplaceOnChanges verifies that changing name, group, or seed
+// triggers a replacement, while blockReads/blockWrites/sizeLimit are updateable.
+func TestDatabaseResource_ReplaceOnChanges(t *testing.T) {
+	t.Parallel()
+
+	server, err := integration.NewServer(t.Context(),
+		"turso",
+		semver.Version{Minor: 1},
+		integration.WithProvider(Provider()),
+	)
+	require.NoError(t, err)
+
+	urn := presource.NewURN("test", "provider", "", "turso:index:Database", "test")
+
+	// Test that changing the name triggers a replace
+	t.Run("name change triggers replace", func(t *testing.T) {
+		diff, err := server.Diff(p.DiffRequest{
+			ID:  "test-db",
+			Urn: urn,
+			State: property.NewMap(map[string]property.Value{
+				"name":  property.New("old-name"),
+				"group": property.New("test-group"),
+			}),
+			Inputs: property.NewMap(map[string]property.Value{
+				"name":  property.New("new-name"),
+				"group": property.New("test-group"),
+			}),
+		})
+		require.NoError(t, err)
+		assert.True(t, diff.HasChanges)
+
+		// Check that name change is a replace
+		nameDiff, ok := diff.DetailedDiff["name"]
+		assert.True(t, ok, "expected name to be in diff")
+		assert.Equal(t, p.UpdateReplace, nameDiff.Kind, "expected name change to trigger replace")
+	})
+
+	// Test that changing group triggers a replace
+	t.Run("group change triggers replace", func(t *testing.T) {
+		diff, err := server.Diff(p.DiffRequest{
+			ID:  "test-db",
+			Urn: urn,
+			State: property.NewMap(map[string]property.Value{
+				"name":  property.New("test-db"),
+				"group": property.New("old-group"),
+			}),
+			Inputs: property.NewMap(map[string]property.Value{
+				"name":  property.New("test-db"),
+				"group": property.New("new-group"),
+			}),
+		})
+		require.NoError(t, err)
+		assert.True(t, diff.HasChanges)
+
+		// Check that group change is a replace
+		groupDiff, ok := diff.DetailedDiff["group"]
+		assert.True(t, ok, "expected group to be in diff")
+		assert.Equal(t, p.UpdateReplace, groupDiff.Kind, "expected group change to trigger replace")
+	})
+
+	// Test that changing blockReads does NOT trigger a replace (it's updateable)
+	t.Run("blockReads change does not trigger replace", func(t *testing.T) {
+		diff, err := server.Diff(p.DiffRequest{
+			ID:  "test-db",
+			Urn: urn,
+			State: property.NewMap(map[string]property.Value{
+				"name":       property.New("test-db"),
+				"group":      property.New("test-group"),
+				"blockReads": property.New(false),
+			}),
+			Inputs: property.NewMap(map[string]property.Value{
+				"name":       property.New("test-db"),
+				"group":      property.New("test-group"),
+				"blockReads": property.New(true),
+			}),
+		})
+		require.NoError(t, err)
+		assert.True(t, diff.HasChanges)
+
+		// Check that blockReads change is NOT a replace
+		blockReadsDiff, ok := diff.DetailedDiff["blockReads"]
+		assert.True(t, ok, "expected blockReads to be in diff")
+		isReplace := blockReadsDiff.Kind == p.AddReplace || blockReadsDiff.Kind == p.DeleteReplace || blockReadsDiff.Kind == p.UpdateReplace
+		assert.False(t, isReplace, "expected blockReads change to NOT trigger replace, got %v", blockReadsDiff.Kind)
+	})
+
+	// Test that changing sizeLimit does NOT trigger a replace (it's updateable)
+	t.Run("sizeLimit change does not trigger replace", func(t *testing.T) {
+		diff, err := server.Diff(p.DiffRequest{
+			ID:  "test-db",
+			Urn: urn,
+			State: property.NewMap(map[string]property.Value{
+				"name":      property.New("test-db"),
+				"group":     property.New("test-group"),
+				"sizeLimit": property.New(""),
+			}),
+			Inputs: property.NewMap(map[string]property.Value{
+				"name":      property.New("test-db"),
+				"group":     property.New("test-group"),
+				"sizeLimit": property.New("1gb"),
+			}),
+		})
+		require.NoError(t, err)
+		assert.True(t, diff.HasChanges)
+
+		// Check that sizeLimit change is NOT a replace
+		sizeLimitDiff, ok := diff.DetailedDiff["sizeLimit"]
+		assert.True(t, ok, "expected sizeLimit to be in diff")
+		isReplace := sizeLimitDiff.Kind == p.AddReplace || sizeLimitDiff.Kind == p.DeleteReplace || sizeLimitDiff.Kind == p.UpdateReplace
+		assert.False(t, isReplace, "expected sizeLimit change to NOT trigger replace, got %v", sizeLimitDiff.Kind)
+	})
+}
+
 func TestDatabaseResource(t *testing.T) {
 	t.Parallel()
 

--- a/provider/databaseTokenResource.go
+++ b/provider/databaseTokenResource.go
@@ -3,11 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/celest-dev/pulumi-turso/provider/internal/tursoclient"
-	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 )
 
@@ -62,7 +60,6 @@ func (state *DatabaseTokenState) Annotate(a infer.Annotator) {
 var (
 	_ infer.CustomCreate[DatabaseTokenArgs, DatabaseTokenState] = (*DatabaseToken)(nil)
 	_ infer.CustomRead[DatabaseTokenArgs, DatabaseTokenState]   = (*DatabaseToken)(nil)
-	_ infer.CustomDiff[DatabaseTokenArgs, DatabaseTokenState]   = (*DatabaseToken)(nil)
 )
 
 func (*DatabaseToken) Create(ctx context.Context, req infer.CreateRequest[DatabaseTokenArgs]) (infer.CreateResponse[DatabaseTokenState], error) {
@@ -129,42 +126,4 @@ func (*DatabaseToken) Create(ctx context.Context, req infer.CreateRequest[Databa
 
 func (*DatabaseToken) Read(ctx context.Context, req infer.ReadRequest[DatabaseTokenArgs, DatabaseTokenState]) (infer.ReadResponse[DatabaseTokenArgs, DatabaseTokenState], error) {
 	return infer.ReadResponse[DatabaseTokenArgs, DatabaseTokenState](req), nil
-}
-
-func (*DatabaseToken) Diff(ctx context.Context, req infer.DiffRequest[DatabaseTokenArgs, DatabaseTokenState]) (infer.DiffResponse, error) {
-	olds := req.State
-	news := req.Inputs
-	diff := map[string]p.PropertyDiff{}
-	if olds.Database != news.Database {
-		diff["database"] = p.PropertyDiff{Kind: p.UpdateReplace}
-	}
-	// Compare authorization values, treating nil as equivalent to not having a value
-	oldAuth := olds.Authorization
-	newAuth := news.Authorization
-	if (oldAuth == nil) != (newAuth == nil) || (oldAuth != nil && newAuth != nil && *oldAuth != *newAuth) {
-		diff["authorization"] = p.PropertyDiff{Kind: p.UpdateReplace}
-	}
-	if !slices.Equal(olds.ReadAttach, news.ReadAttach) {
-		diff["readAttach"] = p.PropertyDiff{Kind: p.UpdateReplace}
-	}
-	// Compare expiration values, treating nil as equivalent to not having a value
-	oldExp := olds.Expiration
-	newExp := news.Expiration
-	if (oldExp == nil) != (newExp == nil) || (oldExp != nil && newExp != nil && *oldExp != *newExp) {
-		diff["expiration"] = p.PropertyDiff{Kind: p.UpdateReplace}
-	}
-	if olds.ExpiresAt != "" {
-		oldExpTime, err := time.Parse(time.RFC3339, olds.ExpiresAt)
-		if err != nil {
-			return infer.DiffResponse{}, fmt.Errorf("error parsing old expiration time: %w", err)
-		}
-		if time.Now().After(oldExpTime) {
-			diff["expiresAt"] = p.PropertyDiff{Kind: p.UpdateReplace}
-		}
-	}
-	return infer.DiffResponse{
-		DeleteBeforeReplace: false,
-		HasChanges:          len(diff) > 0,
-		DetailedDiff:        diff,
-	}, nil
 }

--- a/provider/databaseTokenResource_test.go
+++ b/provider/databaseTokenResource_test.go
@@ -1,174 +1,17 @@
 package provider
 
 import (
-	"context"
 	"testing"
 
 	"github.com/blang/semver"
 	"github.com/golang-jwt/jwt/v5"
 	p "github.com/pulumi/pulumi-go-provider"
-	"github.com/pulumi/pulumi-go-provider/infer"
 	integration "github.com/pulumi/pulumi-go-provider/integration"
 	presource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestDatabaseTokenDiff_AuthorizationPointerComparison(t *testing.T) {
-	t.Parallel()
-
-	token := &DatabaseToken{}
-
-	// Test case 1: Both nil - no diff
-	t.Run("both nil", func(t *testing.T) {
-		resp, err := token.Diff(context.Background(), infer.DiffRequest[DatabaseTokenArgs, DatabaseTokenState]{
-			State: DatabaseTokenState{
-				DatabaseTokenArgs: DatabaseTokenArgs{
-					Database:      "test-db",
-					Authorization: nil,
-				},
-			},
-			Inputs: DatabaseTokenArgs{
-				Database:      "test-db",
-				Authorization: nil,
-			},
-		})
-		require.NoError(t, err)
-		assert.False(t, resp.HasChanges)
-		assert.Empty(t, resp.DetailedDiff)
-	})
-
-	// Test case 2: Same value, different pointers - no diff
-	t.Run("same value different pointers", func(t *testing.T) {
-		authOld := DatabaseTokenAuthorization("full-access")
-		authNew := DatabaseTokenAuthorization("full-access")
-		resp, err := token.Diff(context.Background(), infer.DiffRequest[DatabaseTokenArgs, DatabaseTokenState]{
-			State: DatabaseTokenState{
-				DatabaseTokenArgs: DatabaseTokenArgs{
-					Database:      "test-db",
-					Authorization: &authOld,
-				},
-			},
-			Inputs: DatabaseTokenArgs{
-				Database:      "test-db",
-				Authorization: &authNew,
-			},
-		})
-		require.NoError(t, err)
-		assert.False(t, resp.HasChanges)
-		assert.Empty(t, resp.DetailedDiff)
-	})
-
-	// Test case 3: Different values - should diff
-	t.Run("different values", func(t *testing.T) {
-		authOld := DatabaseTokenAuthorization("full-access")
-		authNew := DatabaseTokenAuthorization("read-only")
-		resp, err := token.Diff(context.Background(), infer.DiffRequest[DatabaseTokenArgs, DatabaseTokenState]{
-			State: DatabaseTokenState{
-				DatabaseTokenArgs: DatabaseTokenArgs{
-					Database:      "test-db",
-					Authorization: &authOld,
-				},
-			},
-			Inputs: DatabaseTokenArgs{
-				Database:      "test-db",
-				Authorization: &authNew,
-			},
-		})
-		require.NoError(t, err)
-		assert.True(t, resp.HasChanges)
-		assert.Contains(t, resp.DetailedDiff, "authorization")
-	})
-
-	// Test case 4: Old nil, new has value - should diff
-	t.Run("old nil new has value", func(t *testing.T) {
-		authNew := DatabaseTokenAuthorization("full-access")
-		resp, err := token.Diff(context.Background(), infer.DiffRequest[DatabaseTokenArgs, DatabaseTokenState]{
-			State: DatabaseTokenState{
-				DatabaseTokenArgs: DatabaseTokenArgs{
-					Database:      "test-db",
-					Authorization: nil,
-				},
-			},
-			Inputs: DatabaseTokenArgs{
-				Database:      "test-db",
-				Authorization: &authNew,
-			},
-		})
-		require.NoError(t, err)
-		assert.True(t, resp.HasChanges)
-		assert.Contains(t, resp.DetailedDiff, "authorization")
-	})
-
-	// Test case 5: Old has value, new nil - should diff
-	t.Run("old has value new nil", func(t *testing.T) {
-		authOld := DatabaseTokenAuthorization("full-access")
-		resp, err := token.Diff(context.Background(), infer.DiffRequest[DatabaseTokenArgs, DatabaseTokenState]{
-			State: DatabaseTokenState{
-				DatabaseTokenArgs: DatabaseTokenArgs{
-					Database:      "test-db",
-					Authorization: &authOld,
-				},
-			},
-			Inputs: DatabaseTokenArgs{
-				Database:      "test-db",
-				Authorization: nil,
-			},
-		})
-		require.NoError(t, err)
-		assert.True(t, resp.HasChanges)
-		assert.Contains(t, resp.DetailedDiff, "authorization")
-	})
-}
-
-func TestDatabaseTokenDiff_ExpirationPointerComparison(t *testing.T) {
-	t.Parallel()
-
-	token := &DatabaseToken{}
-
-	// Test case: Same expiration value, different pointers - no diff
-	t.Run("same value different pointers", func(t *testing.T) {
-		expOld := "1h"
-		expNew := "1h"
-		resp, err := token.Diff(context.Background(), infer.DiffRequest[DatabaseTokenArgs, DatabaseTokenState]{
-			State: DatabaseTokenState{
-				DatabaseTokenArgs: DatabaseTokenArgs{
-					Database:   "test-db",
-					Expiration: &expOld,
-				},
-			},
-			Inputs: DatabaseTokenArgs{
-				Database:   "test-db",
-				Expiration: &expNew,
-			},
-		})
-		require.NoError(t, err)
-		assert.False(t, resp.HasChanges)
-		assert.Empty(t, resp.DetailedDiff)
-	})
-
-	// Test case: Different expiration values - should diff
-	t.Run("different values", func(t *testing.T) {
-		expOld := "1h"
-		expNew := "2h"
-		resp, err := token.Diff(context.Background(), infer.DiffRequest[DatabaseTokenArgs, DatabaseTokenState]{
-			State: DatabaseTokenState{
-				DatabaseTokenArgs: DatabaseTokenArgs{
-					Database:   "test-db",
-					Expiration: &expOld,
-				},
-			},
-			Inputs: DatabaseTokenArgs{
-				Database:   "test-db",
-				Expiration: &expNew,
-			},
-		})
-		require.NoError(t, err)
-		assert.True(t, resp.HasChanges)
-		assert.Contains(t, resp.DetailedDiff, "expiration")
-	})
-}
 
 func TestDatabaseTokenResource(t *testing.T) {
 	t.Parallel()

--- a/provider/groupResource.go
+++ b/provider/groupResource.go
@@ -18,8 +18,8 @@ func (g *Group) Annotate(a infer.Annotator) {
 }
 
 type GroupArgs struct {
-	Name             string   `pulumi:"name"`
-	PrimaryLocation  string   `pulumi:"primaryLocation"`
+	Name             string   `pulumi:"name" provider:"replaceOnChanges"`
+	PrimaryLocation  string   `pulumi:"primaryLocation" provider:"replaceOnChanges"`
 	ReplicaLocations []string `pulumi:"replicaLocations,optional"`
 	Extensions       []string `pulumi:"extensions,optional"`
 }
@@ -54,9 +54,7 @@ func (s *GroupState) Annotate(a infer.Annotator) {
 var (
 	_ infer.CustomCreate[GroupArgs, GroupState] = (*Group)(nil)
 	_ infer.CustomRead[GroupArgs, GroupState]   = (*Group)(nil)
-	_ infer.CustomUpdate[GroupArgs, GroupState] = (*Group)(nil)
 	_ infer.CustomDelete[GroupState]            = (*Group)(nil)
-	_ infer.CustomDiff[GroupArgs, GroupState]   = (*Group)(nil)
 )
 
 func (*Group) Create(ctx context.Context, req infer.CreateRequest[GroupArgs]) (infer.CreateResponse[GroupState], error) {
@@ -149,10 +147,6 @@ func (*Group) Read(ctx context.Context, req infer.ReadRequest[GroupArgs, GroupSt
 	}, nil
 }
 
-func (*Group) Update(ctx context.Context, req infer.UpdateRequest[GroupArgs, GroupState]) (infer.UpdateResponse[GroupState], error) {
-	panic("updating groups is not supported")
-}
-
 func (*Group) Delete(ctx context.Context, req infer.DeleteRequest[GroupState]) (infer.DeleteResponse, error) {
 	p.GetLogger(ctx).Infof("deleting group %s", req.ID)
 
@@ -168,25 +162,6 @@ func (*Group) Delete(ctx context.Context, req infer.DeleteRequest[GroupState]) (
 	}
 
 	return infer.DeleteResponse{}, nil
-}
-
-func (*Group) Diff(ctx context.Context, req infer.DiffRequest[GroupArgs, GroupState]) (infer.DiffResponse, error) {
-	olds := req.State
-	news := req.Inputs
-	diff := map[string]p.PropertyDiff{}
-	deleteBeforeReplace := false
-	if olds.Name != news.Name {
-		diff["name"] = p.PropertyDiff{Kind: p.UpdateReplace}
-	}
-	if olds.Primary != news.PrimaryLocation {
-		diff["primaryLocation"] = p.PropertyDiff{Kind: p.UpdateReplace}
-		deleteBeforeReplace = true
-	}
-	return infer.DiffResponse{
-		DeleteBeforeReplace: deleteBeforeReplace,
-		HasChanges:          len(diff) > 0,
-		DetailedDiff:        diff,
-	}, nil
 }
 
 func (config Config) readGroupResource(ctx context.Context, name string) (GroupState, error) {

--- a/provider/groupResource_test.go
+++ b/provider/groupResource_test.go
@@ -14,6 +14,68 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestGroupResource_ReplaceOnChanges verifies that changing name or primaryLocation
+// triggers a replacement, not an update.
+func TestGroupResource_ReplaceOnChanges(t *testing.T) {
+	t.Parallel()
+
+	server, err := integration.NewServer(t.Context(),
+		"turso",
+		semver.Version{Minor: 1},
+		integration.WithProvider(Provider()),
+	)
+	require.NoError(t, err)
+
+	urn := presource.NewURN("test", "provider", "", "turso:index:Group", "test")
+
+	// Test that changing the name triggers a replace
+	t.Run("name change triggers replace", func(t *testing.T) {
+		diff, err := server.Diff(p.DiffRequest{
+			ID:  "test-group",
+			Urn: urn,
+			State: property.NewMap(map[string]property.Value{
+				"name":    property.New("old-name"),
+				"primary": property.New("aws-us-east-1"),
+			}),
+			Inputs: property.NewMap(map[string]property.Value{
+				"name":            property.New("new-name"),
+				"primaryLocation": property.New("aws-us-east-1"),
+			}),
+		})
+		require.NoError(t, err)
+		assert.True(t, diff.HasChanges)
+
+		// Check that name change is a replace
+		nameDiff, ok := diff.DetailedDiff["name"]
+		assert.True(t, ok, "expected name to be in diff")
+		assert.Equal(t, p.UpdateReplace, nameDiff.Kind, "expected name change to trigger replace")
+	})
+
+	// Test that changing primaryLocation triggers a replace
+	t.Run("primaryLocation change triggers replace", func(t *testing.T) {
+		diff, err := server.Diff(p.DiffRequest{
+			ID:  "test-group",
+			Urn: urn,
+			State: property.NewMap(map[string]property.Value{
+				"name":            property.New("test-group"),
+				"primaryLocation": property.New("aws-us-east-1"),
+			}),
+			Inputs: property.NewMap(map[string]property.Value{
+				"name":            property.New("test-group"),
+				"primaryLocation": property.New("aws-us-west-2"),
+			}),
+		})
+		require.NoError(t, err)
+		assert.True(t, diff.HasChanges)
+
+		// Check that primaryLocation change is a replace (could be UpdateReplace or AddReplace)
+		locationDiff, ok := diff.DetailedDiff["primaryLocation"]
+		assert.True(t, ok, "expected primaryLocation to be in diff")
+		isReplace := locationDiff.Kind == p.UpdateReplace || locationDiff.Kind == p.AddReplace
+		assert.True(t, isReplace, "expected primaryLocation change to trigger replace, got %v", locationDiff.Kind)
+	})
+}
+
 func TestGroupResource(t *testing.T) {
 	t.Parallel()
 
@@ -31,7 +93,7 @@ func TestGroupResource(t *testing.T) {
 	integration.LifeCycleTest{
 		Resource: "turso:index:Group",
 		Create: integration.Operation{
-			Inputs: presource.FromResourcePropertyMap(presource.NewPropertyMapFromMap(map[string]interface{}{
+			Inputs: presource.FromResourcePropertyMap(presource.NewPropertyMapFromMap(map[string]any{
 				"name":            groupName,
 				"primaryLocation": "aws-us-east-1",
 			})),
@@ -56,18 +118,14 @@ func TestGroupResource_ChangeName(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	err = server.Configure(p.ConfigureRequest{
-		Args: presource.FromResourcePropertyMap(presource.NewPropertyMapFromMap(map[string]interface{}{
-			"organization": "celest-dev",
-		})),
-	})
+	err = server.Configure(p.ConfigureRequest{})
 	require.NoError(t, err)
 
 	groupName := fmt.Sprintf("test-%d", rand.IntN(100000))
 	integration.LifeCycleTest{
 		Resource: "turso:index:Group",
 		Create: integration.Operation{
-			Inputs: presource.FromResourcePropertyMap(presource.NewPropertyMapFromMap(map[string]interface{}{
+			Inputs: presource.FromResourcePropertyMap(presource.NewPropertyMapFromMap(map[string]any{
 				"name":            groupName,
 				"primaryLocation": "aws-us-east-1",
 			})),
@@ -81,7 +139,7 @@ func TestGroupResource_ChangeName(t *testing.T) {
 		},
 		Updates: []integration.Operation{
 			{
-				Inputs: presource.FromResourcePropertyMap(presource.NewPropertyMapFromMap(map[string]interface{}{
+				Inputs: presource.FromResourcePropertyMap(presource.NewPropertyMapFromMap(map[string]any{
 					"name":            groupName + "-updated",
 					"primaryLocation": "aws-us-east-1",
 				})),

--- a/provider/groupTokenResource.go
+++ b/provider/groupTokenResource.go
@@ -3,11 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/celest-dev/pulumi-turso/provider/internal/tursoclient"
-	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
 )
 
@@ -62,7 +60,6 @@ func (state *GroupTokenState) Annotate(a infer.Annotator) {
 var (
 	_ infer.CustomCreate[GroupTokenArgs, GroupTokenState] = (*GroupToken)(nil)
 	_ infer.CustomRead[GroupTokenArgs, GroupTokenState]   = (*GroupToken)(nil)
-	_ infer.CustomDiff[GroupTokenArgs, GroupTokenState]   = (*GroupToken)(nil)
 )
 
 func (*GroupToken) Create(ctx context.Context, req infer.CreateRequest[GroupTokenArgs]) (infer.CreateResponse[GroupTokenState], error) {
@@ -129,42 +126,4 @@ func (*GroupToken) Create(ctx context.Context, req infer.CreateRequest[GroupToke
 
 func (*GroupToken) Read(ctx context.Context, req infer.ReadRequest[GroupTokenArgs, GroupTokenState]) (infer.ReadResponse[GroupTokenArgs, GroupTokenState], error) {
 	return infer.ReadResponse[GroupTokenArgs, GroupTokenState](req), nil
-}
-
-func (*GroupToken) Diff(ctx context.Context, req infer.DiffRequest[GroupTokenArgs, GroupTokenState]) (infer.DiffResponse, error) {
-	olds := req.State
-	news := req.Inputs
-	diff := map[string]p.PropertyDiff{}
-	if olds.Group != news.Group {
-		diff["group"] = p.PropertyDiff{Kind: p.UpdateReplace}
-	}
-	// Compare authorization values, treating nil as equivalent to not having a value
-	oldAuth := olds.Authorization
-	newAuth := news.Authorization
-	if (oldAuth == nil) != (newAuth == nil) || (oldAuth != nil && newAuth != nil && *oldAuth != *newAuth) {
-		diff["authorization"] = p.PropertyDiff{Kind: p.UpdateReplace}
-	}
-	if !slices.Equal(olds.ReadAttach, news.ReadAttach) {
-		diff["readAttach"] = p.PropertyDiff{Kind: p.UpdateReplace}
-	}
-	// Compare expiration values, treating nil as equivalent to not having a value
-	oldExp := olds.Expiration
-	newExp := news.Expiration
-	if (oldExp == nil) != (newExp == nil) || (oldExp != nil && newExp != nil && *oldExp != *newExp) {
-		diff["expiration"] = p.PropertyDiff{Kind: p.UpdateReplace}
-	}
-	if olds.ExpiresAt != "" {
-		oldExpTime, err := time.Parse(time.RFC3339, olds.ExpiresAt)
-		if err != nil {
-			return infer.DiffResponse{}, fmt.Errorf("error parsing old expiration time: %w", err)
-		}
-		if time.Now().After(oldExpTime) {
-			diff["expiresAt"] = p.PropertyDiff{Kind: p.UpdateReplace}
-		}
-	}
-	return infer.DiffResponse{
-		DeleteBeforeReplace: false,
-		HasChanges:          len(diff) > 0,
-		DetailedDiff:        diff,
-	}, nil
 }


### PR DESCRIPTION
Instead of overriding Diff, which internally handles more than what we were handling, use schema to drive the custom behavior we need.